### PR TITLE
Fix: honour isSelectedSite for Power Shout bookings

### DIFF
--- a/custom_components/genesisenergy/__init__.py
+++ b/custom_components/genesisenergy/__init__.py
@@ -90,13 +90,29 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         base_start_dt = start_dt_raw.replace(minute=0, second=0, microsecond=0)
         LOGGER.info(f"Attempting to book Power Shout for {requested_duration} hour(s) starting at {base_start_dt}")
-
+# Fix: honour isSelectedSite for Power Shout bookings
+# Power Shout bookings previously always used eligibleBillingAccounts[0]. Now uses the user's selected site (matching webSelectedSite), with fallback to [0] if none is flagged.
         ps_info = coordinator.data.get(DATA_API_POWERSHOUT_INFO)
 
         supply_agreement_id, supply_point_id, loyalty_account_id = None, None, None
         try:
             loyalty_account_id = ps_info.get("loyaltyAccountId")
-            supply_point_data = ps_info["eligibleBillingAccounts"][0]["billingAccountSites"][0]["supplyPoints"][0]
+            
+            # Find the account marked as the user's currently selected site
+            # (matches webSelectedSite from the Genesis web portal)
+            supply_point_data = None
+            for account in ps_info.get("eligibleBillingAccounts", []):
+                for site in account.get("billingAccountSites", []):
+                    if site.get("isSelectedSite") is True:
+                        supply_point_data = site["supplyPoints"][0]
+                        break
+                if supply_point_data:
+                    break
+            
+            # Fallback to first eligible account if none flagged as selected
+            if not supply_point_data:
+                supply_point_data = ps_info["eligibleBillingAccounts"][0]["billingAccountSites"][0]["supplyPoints"][0]
+            
             supply_agreement_id = supply_point_data.get("supplyAgreementId")
             supply_point_id = supply_point_data.get("id")
         except (KeyError, IndexError, TypeError):


### PR DESCRIPTION
## Summary

Power Shout bookings always used the first eligible billing account 
instead of the user's currently selected one.

## Background

I have four billing accounts on one Genesis login. When I select my home 
property in the Genesis web portal, sensor data correctly follows the 
selection (`webSelectedSite`), but `add_powershout_booking` always books 
against the first entry in `eligibleBillingAccounts` — which in my case 
is a different property.

The Genesis web portal Power Shout booking flow does NOT exhibit this — 
it correctly defaults to the selected property. So the API supports 
per-call account selection; the integration just wasn't using the 
available signal.

## Root cause

In `__init__.py`, `async_add_powershout_booking_service` hardcodes index 0:

```python
supply_point_data = ps_info["eligibleBillingAccounts"][0]["billingAccountSites"][0]["supplyPoints"][0]
```

The `eligibleBillingAccounts` payload includes an `isSelectedSite: true` 
boolean on the site that tracks `webSelectedSite`.

## Fix

Honour `isSelectedSite` when selecting which billing account to book 
against. Iterate through the sites, pick the one flagged as selected, 
and fall back to index 0 if none is flagged (defensive — e.g. for 
single-account users).

No new config options needed — the integration already implicitly 
respects `webSelectedSite` for sensor reads. This just extends that 
behaviour to bookings.

## Testing

Tested locally with my own multi-account setup. With `webSelectedSite` 
pointed at my home property, the booking service now correctly books 
against that property. Confirmed via the Genesis app showing which 
account received the booking.

## Notes

- I have not run `scripts/lint` locally. Happy to if needed.